### PR TITLE
fix: attribute.configurable `false -> true`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,7 @@ const addStringMethod = (key: string, getter: (value: string) => string): unknow
     get() {
       return getter(this)
     },
+    configurable: true,
   })
 
 /**


### PR DESCRIPTION
- `Object.defineProperty` 의 `attribute.configurable` 을 true 로 수정했습니다. (기본값 = false)
- nextjs 에서 개발 중 ` ⨯ TypeError: Cannot redefine property: 은는` 에러가 발생하여 PR 올립니다.
```text
/Users/ppojin/.nvm/versions/node/v18.19.0/bin/npm run dev

> dev
> next

   ▲ Next.js 14.0.4
   - Local:        http://localhost:3000
   - Environments: .env.development

 ✓ Ready in 4.2s
 ○ Compiling / ...
 ✓ Compiled / in 5.3s (3469 modules)
 ✓ Compiled in 3s (3469 modules)
 ✓ Compiled in 5.5s (3469 modules)
 ⨯ node_modules/.pnpm/josa-complete@2.1.3-1/node_modules/josa-complete/dist/index.js (97:7) @ defineProperty
 ⨯ TypeError: Cannot redefine property: 은는
    at Function.defineProperty (<anonymous>)
    at __webpack_require__ (/Users/mz01-hjhwang/blog/cms-front/.next/server/webpack-runtime.js:33:43)
    at eval (./lib/validation/validation.ts:11:71)
    at (ssr)/./lib/validation/validation.ts (/Users/mz01-hjhwang/blog/cms-front/.next/server/app/contract/list/page.js:919:1)
    at __webpack_require__ (/Users/mz01-hjhwang/blog/cms-front/.next/server/webpack-runtime.js:33:43)
    at eval (./lib/validation/sales/searchListValidator.ts:5:69)
    at (ssr)/./lib/validation/sales/searchListValidator.ts (/Users/mz01-hjhwang/blog/cms-front/.next/server/app/contract/list/page.js:908:1)
    at __webpack_require__ (/Users/mz01-hjhwang/blog/cms-front/.next/server/webpack-runtime.js:33:43)
    at eval (./app/contract/list/page.tsx:18:99)
    at (ssr)/./app/contract/list/page.tsx (/Users/mz01-hjhwang/blog/cms-front/.next/server/app/contract/list/page.js:347:1)
    at __webpack_require__ (/Users/mz01-hjhwang/blog/cms-front/.next/server/webpack-runtime.js:33:43)
    at JSON.parse (<anonymous>)
null
```